### PR TITLE
Compose for MongoDB services may come with clustering.

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -158,7 +158,8 @@ function chatLogs(owner, conversation, response) {
     var options = {
         safe: true,
         upsert: true,
-        new: true
+        new: true,
+        w: 'majority'
     };
 
     var query = {


### PR DESCRIPTION
specify the ‘w’ option in this case to avoid   { MongoError: w: 'majority' is the only valid write concern when writing to config server replica sets, got: { w: 1, wtimeout: 0 }